### PR TITLE
Update 2.self-hosting.md

### DIFF
--- a/content/5.open-source/2.self-hosting.md
+++ b/content/5.open-source/2.self-hosting.md
@@ -63,7 +63,9 @@ Here are four different use cases. Please refer to their APP_HOMEPAGE_URL settin
 Run on your own computer
 
 ```yaml [docker-compose.yml]
-version: '3'
+networks:
+  keydb:
+  mongo:
 
 services:
   heyform:
@@ -105,7 +107,9 @@ services:
 Connect MongoDB with username and password
 
 ```yaml [docker-compose.yml]
-version: '3'
+networks:
+  keydb:
+  mongo:
 
 services:
   heyform:
@@ -193,7 +197,9 @@ services:
 Deploy to a public server
 
 ```yaml [docker-compose.yml]
-version: '3'
+networks:
+  keydb:
+  mongo:
 
 services:
   heyform:

--- a/content/5.open-source/2.self-hosting.md
+++ b/content/5.open-source/2.self-hosting.md
@@ -77,6 +77,8 @@ services:
     depends_on:
       - mongo
       - keydb
+    ports:
+      - '9513:8000'
     environment:
       APP_HOMEPAGE_URL: http://127.0.0.1:9513
       SESSION_KEY: key1
@@ -121,6 +123,8 @@ services:
     depends_on:
       - mongo
       - keydb
+    ports:
+      - '9513:8000'
     environment:
       APP_HOMEPAGE_URL: http://127.0.0.1:9513
       SESSION_KEY: key1
@@ -167,6 +171,8 @@ services:
     depends_on:
       - mongo
       - keydb
+    ports:
+      - '9513:8000'
     environment:
       APP_HOMEPAGE_URL: http://192.168.1.50:9513
       SESSION_KEY: key1
@@ -211,6 +217,8 @@ services:
     depends_on:
       - mongo
       - keydb
+    ports:
+      - '9513:8000'
     environment:
       APP_HOMEPAGE_URL: http://form.yourcompany.com
       SESSION_KEY: key1

--- a/content/5.open-source/2.self-hosting.md
+++ b/content/5.open-source/2.self-hosting.md
@@ -1,4 +1,5 @@
 ---
+
 title: Self-Hosting
 icon: 'lucide:server'
 description: Setup guidelines for self-hosted HeyForm.
@@ -47,7 +48,7 @@ For macOS users, you can install them by [Homebrew](https://brew.sh/):
 brew install docker docker-compose
 ```
 
-For Windows users, you can install them by [Chocolatey](https://chocolatey.org/)**:**
+For Windows users, you can install them by [Chocolatey](https://chocolatey.org/):
 
 ```bash
 choco install docker-desktop docker-compose -y
@@ -65,45 +66,37 @@ Run on your own computer
 version: '3'
 
 services:
-heyform:
-  image: heyform/community-edition:latest
-  restart: always
-  volumes:
-    # Perist uploaded images
-    - ./assets:/app/static/upload
-  depends_on:
-    - mongo
-    - redis
-  ports:
-    - '9513:8000'
-  environment:
-    # The homepage of a website is the URL that you open in your browser
-    # The port here should be consistent with the exposed one (should be 9513 NOT 8000)
-    APP_HOMEPAGE_URL: http://127.0.0.1:9513
-    SESSION_KEY: key1
-    FORM_ENCRYPTION_KEY: key2
-    MONGO_URI: 'mongodb://mongo:27017/heyform'
-    REDIS_HOST: redis
-    REDIS_PORT: 6379
+  heyform:
+    image: heyform/community-edition:latest
+    restart: always
+    volumes:
+      # Persist uploaded images
+      - ./assets:/app/static/upload
+    depends_on:
+      - mongo
+      - keydb
+    environment:
+      APP_HOMEPAGE_URL: http://127.0.0.1:9513
+      SESSION_KEY: key1
+      FORM_ENCRYPTION_KEY: key2
+      MONGO_URI: 'mongodb://mongo:27017/heyform'
+      REDIS_HOST: keydb
+      REDIS_PORT: 6379
 
-mongo:
-  image: mongo:4.4.29
-  restart: always
-  volumes:
-    # Persist mongodb data
-    - ./database:/data/db
-  ports:
-    - '27017:27017'
+  mongo:
+    image: percona/percona-server-mongodb:4.4
+    restart: always
+    volumes:
+      # Persist MongoDB data
+      - ./database:/data/db
 
-redis:
-  image: redis
-  restart: always
-  command: redis-server --appendonly yes
-  volumes:
-    # Persist redis data
-    - ./redis:/data
-  ports:
-    - '6379:6379'
+  keydb:
+    image: snapkeydb/keydb:latest
+    restart: always
+    command: keydb-server --appendonly yes
+    volumes:
+      # Persist KeyDB data
+      - ./keydb:/data
 ```
 ::
 
@@ -115,50 +108,42 @@ Connect MongoDB with username and password
 version: '3'
 
 services:
-heyform:
-  image: heyform/community-edition:latest
-  restart: always
-  volumes:
-    # Perist uploaded images
-    - ./assets:/app/static/upload
-  depends_on:
-    - mongo
-    - redis
-  ports:
-    - '9513:8000'
-  environment:
-    # The homepage of a website is the URL that you open in your browser
-    # The port here should be consistent with the exposed port (should be :9513 NOT 8000)
-    APP_HOMEPAGE_URL: http://127.0.0.1:9513
-    SESSION_KEY: key1
-    FORM_ENCRYPTION_KEY: key2
-    MONGO_URI: 'mongodb://mongo:27017/heyform?authSource=admin'
-    MONGO_USER: root
-    MONGO_PASSWORD: passexample
-    REDIS_HOST: redis
-    REDIS_PORT: 6379
+  heyform:
+    image: heyform/community-edition:latest
+    restart: always
+    volumes:
+      # Persist uploaded images
+      - ./assets:/app/static/upload
+    depends_on:
+      - mongo
+      - keydb
+    environment:
+      APP_HOMEPAGE_URL: http://127.0.0.1:9513
+      SESSION_KEY: key1
+      FORM_ENCRYPTION_KEY: key2
+      MONGO_URI: 'mongodb://mongo:27017/heyform?authSource=admin'
+      MONGO_USER: root
+      MONGO_PASSWORD: passexample
+      REDIS_HOST: keydb
+      REDIS_PORT: 6379
 
-mongo:
-  image: mongo:4.4.29
-  restart: always
-  volumes:
-    # Persist mongodb data
-    - ./database:/data/db
-  ports:
-    - '27017:27017'
-  environment:
-    MONGO_INITDB_ROOT_USERNAME: root
-    MONGO_INITDB_ROOT_PASSWORD: passexample
+  mongo:
+    image: percona/percona-server-mongodb:4.4
+    restart: always
+    volumes:
+      # Persist MongoDB data
+      - ./database:/data/db
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: passexample
 
-redis:
-  image: redis
-  restart: always
-  command: redis-server --appendonly yes
-  volumes:
-    # Persist redis data
-    - ./redis:/data
-  ports:
-    - '6379:6379'
+  keydb:
+    image: snapkeydb/keydb:latest
+    restart: always
+    command: keydb-server --appendonly yes
+    volumes:
+      # Persist KeyDB data
+      - ./keydb:/data
 ```
 ::
 
@@ -169,44 +154,37 @@ Allow other computers in the local network to access
 version: '3'
 
 services:
-heyform:
-  image: heyform/community-edition:latest
-  restart: always
-  volumes:
-    # Perist uploaded images
-    - ./assets:/app/static/upload
-  depends_on:
-    - mongo
-    - redis
-  ports:
-    - '9513:8000'
-  environment:
-    # **Your IP address in the local network**, e.g. 192.168.1.50.
-    APP_HOMEPAGE_URL: http://192.168.1.50:9513
-    SESSION_KEY: key1
-    FORM_ENCRYPTION_KEY: key2
-    MONGO_URI: 'mongodb://mongo:27017/heyform'
-    REDIS_HOST: redis
-    REDIS_PORT: 6379
+  heyform:
+    image: heyform/community-edition:latest
+    restart: always
+    volumes:
+      # Persist uploaded images
+      - ./assets:/app/static/upload
+    depends_on:
+      - mongo
+      - keydb
+    environment:
+      APP_HOMEPAGE_URL: http://192.168.1.50:9513
+      SESSION_KEY: key1
+      FORM_ENCRYPTION_KEY: key2
+      MONGO_URI: 'mongodb://mongo:27017/heyform'
+      REDIS_HOST: keydb
+      REDIS_PORT: 6379
 
-mongo:
-  image: mongo:4.4.29
-  restart: always
-  volumes:
-    # Persist mongodb data
-    - ./database:/data/db
-  ports:
-    - '27017:27017'
+  mongo:
+    image: percona/percona-server-mongodb:4.4
+    restart: always
+    volumes:
+      # Persist MongoDB data
+      - ./database:/data/db
 
-redis:
-  image: redis
-  restart: always
-  command: redis-server --appendonly yes
-  volumes:
-    # Persist redis data
-    - ./redis:/data
-  ports:
-    - '6379:6379'
+  keydb:
+    image: snapkeydb/keydb:latest
+    restart: always
+    command: keydb-server --appendonly yes
+    volumes:
+      # Persist KeyDB data
+      - ./keydb:/data
 ```
 ::
 
@@ -218,44 +196,37 @@ Deploy to a public server
 version: '3'
 
 services:
-heyform:
-  image: heyform/community-edition:latest
-  restart: always
-  volumes:
-    # Perist uploaded images
-    - ./assets:/app/static/upload
-  depends_on:
-    - mongo
-    - redis
-  ports:
-    - '9513:8000'
-  environment:
-    # Your website homepage URL, e.g. **http**://form.yourcompany.com
-    APP_HOMEPAGE_URL: http://form.yourcompany.com
-    SESSION_KEY: key1
-    FORM_ENCRYPTION_KEY: key2
-    MONGO_URI: 'mongodb://mongo:27017/heyform'
-    REDIS_HOST: redis
-    REDIS_PORT: 6379
+  heyform:
+    image: heyform/community-edition:latest
+    restart: always
+    volumes:
+      # Persist uploaded images
+      - ./assets:/app/static/upload
+    depends_on:
+      - mongo
+      - keydb
+    environment:
+      APP_HOMEPAGE_URL: http://form.yourcompany.com
+      SESSION_KEY: key1
+      FORM_ENCRYPTION_KEY: key2
+      MONGO_URI: 'mongodb://mongo:27017/heyform'
+      REDIS_HOST: keydb
+      REDIS_PORT: 6379
 
-mongo:
-  image: mongo:4.4.29
-  restart: always
-  volumes:
-    # Persist mongodb data
-    - ./database:/data/db
-  ports:
-    - '27017:27017'
+  mongo:
+    image: percona/percona-server-mongodb:4.4
+    restart: always
+    volumes:
+      # Persist MongoDB data
+      - ./database:/data/db
 
-redis:
-  image: redis
-  restart: always
-  command: redis-server --appendonly yes
-  volumes:
-    # Persist redis data
-    - ./redis:/data
-  ports:
-    - '6379:6379'
+  keydb:
+    image: snapkeydb/keydb:latest
+    restart: always
+    command: keydb-server --appendonly yes
+    volumes:
+      # Persist KeyDB data
+      - ./keydb:/data
 ```
 
 ```yaml [docker-compose.yml]
@@ -263,16 +234,16 @@ redis:
 # To deploy to a public server, you will also need to configure nginx for reverse proxying the NodeJs program
 
 server {
-listen 80;
-server_name form.yourcompany.com;
+  listen 80;
+  server_name form.yourcompany.com;
 
-location / {
-proxy_pass http://127.0.0.1:9513;
-proxy_set_header Host $host;
-proxy_set_header X-Real-IP $remote_addr;
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-proxy_set_header REMOTE-HOST $remote_addr;
-}
+  location / {
+    proxy_pass http://heyform:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header REMOTE-HOST $remote_addr;
+  }
 }
 ```
 ::
@@ -289,6 +260,6 @@ When you run this command, by default, it does the following:
 
 - Create a database
 - Run the migrations
-- Start the HeyForm web app on port 9513
+- Start the HeyForm web app on port 8000
 
-You can now navigate to `http://<server ip>:9513` or `http://form.yourcompany.com` and see the login screen. HeyForm itself does not perform SSL termination. It only runs on unencrypted HTTP. If you want to run on HTTPS you also need to set up a reverse proxy in front of the server.
+You can now navigate to `http://<server ip>:8000` or `http://form.yourcompany.com` and see the login screen. HeyForm itself does not perform SSL termination. It only runs on unencrypted HTTP. If you want to run on HTTPS you also need to set up a reverse proxy in front of the server.

--- a/content/5.open-source/2.self-hosting.md
+++ b/content/5.open-source/2.self-hosting.md
@@ -244,7 +244,7 @@ server {
   server_name form.yourcompany.com;
 
   location / {
-    proxy_pass http://heyform:8000;
+    proxy_pass http://heyform:9513;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -266,6 +266,6 @@ When you run this command, by default, it does the following:
 
 - Create a database
 - Run the migrations
-- Start the HeyForm web app on port 8000
+- Start the HeyForm web app on port 9513
 
-You can now navigate to `http://<server ip>:8000` or `http://form.yourcompany.com` and see the login screen. HeyForm itself does not perform SSL termination. It only runs on unencrypted HTTP. If you want to run on HTTPS you also need to set up a reverse proxy in front of the server.
+You can now navigate to `http://<server ip>:9513` or `http://form.yourcompany.com` and see the login screen. HeyForm itself does not perform SSL termination. It only runs on unencrypted HTTP. If you want to run on HTTPS you also need to set up a reverse proxy in front of the server.


### PR DESCRIPTION
I've made some tweaks here so that you don't instruct users to publish ports to their host machine unprotected.
I've also ensured that you are using products with healthier licenses. They are drop-in replacement tools, which should mean that they will maintain feature parity with the intended things they replace, like Redis and Mongo. You won't be able to back your projects with tools that have a long shelf life, and they may be forked in the future if they stop being supported by their teams.

Snapchat makes Keydb, which can scale more easily. The scalability isn't behind a paywall, and their primary business model isn't Redis servers, so you can probably expect they will not be prioritizing screwing with it.

PerconaDB is about the only Mongo drop-in, but it seems compatible with everything I find, so I recommend it over Mongodb itself and its strange SSBL license.