### PR TITLE
Update 2.self-hosting.md with correct keydb docker image

### DIFF
--- a/content/5.open-source/2.self-hosting.md
+++ b/content/5.open-source/2.self-hosting.md
@@ -95,7 +95,7 @@ services:
       - ./database:/data/db
 
   keydb:
-    image: snapkeydb/keydb:latest
+    image: eqalpha/keydb:latest
     restart: always
     command: keydb-server --appendonly yes
     volumes:
@@ -146,7 +146,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: passexample
 
   keydb:
-    image: snapkeydb/keydb:latest
+    image: eqalpha/keydb:latest
     restart: always
     command: keydb-server --appendonly yes
     volumes:
@@ -189,7 +189,7 @@ services:
       - ./database:/data/db
 
   keydb:
-    image: snapkeydb/keydb:latest
+    image: eqalpha/keydb:latest
     restart: always
     command: keydb-server --appendonly yes
     volumes:
@@ -235,7 +235,7 @@ services:
       - ./database:/data/db
 
   keydb:
-    image: snapkeydb/keydb:latest
+    image: eqalpha/keydb:latest
     restart: always
     command: keydb-server --appendonly yes
     volumes:


### PR DESCRIPTION
Corrected the docker repository for KeyDB as per the official documentation https://docs.keydb.dev/docs/docker-basics/#start-a-keydb-instance