### PR TITLE
Typo Fix on selfhosting page

### DIFF
--- a/content/5.open-source/2.self-hosting.md
+++ b/content/5.open-source/2.self-hosting.md
@@ -259,7 +259,7 @@ volumes:
   keydb:
 ```
 
-```yaml [docker-compose.yml]
+```yaml [nginx.conf]
 # Nginx config
 # To deploy to a public server, you will also need to configure nginx for reverse proxying the NodeJs program
 


### PR DESCRIPTION
Small typo fix on the selfhosting page where the title for the nginx.conf file has the title of docker-compose.yml

Current: 
![image](https://github.com/user-attachments/assets/d91947bd-51d3-418c-845a-7cd72da4bde4)

Update:
![image](https://github.com/user-attachments/assets/2dc61abd-3222-477c-b508-400fdb1b7814)
